### PR TITLE
Final fix to activity feed!

### DIFF
--- a/src/main/java/codeu/controller/ActivityServlet.java
+++ b/src/main/java/codeu/controller/ActivityServlet.java
@@ -16,6 +16,9 @@ import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.MessageStore;
+import codeu.model.data.Message;
+
 
 /** Servlet class responsible for the conversations page. */
 public class ActivityServlet extends HttpServlet {
@@ -26,6 +29,9 @@ public class ActivityServlet extends HttpServlet {
   /** Store class that gives access to Conversations. */
   private ConversationStore conversationStore;
 
+/** Store class that gives access to Messages. */
+private MessageStore messageStore;
+
   /**
    * Set up state for handling conversation-related requests. This method is only called when
    * running in a server, not when running in a test.
@@ -35,6 +41,7 @@ public class ActivityServlet extends HttpServlet {
     super.init();
     setUserStore(UserStore.getInstance());
     setConversationStore(ConversationStore.getInstance());
+    setMessageStore(MessageStore.getInstance());
   }
 
   /**
@@ -53,6 +60,16 @@ public class ActivityServlet extends HttpServlet {
     this.conversationStore = conversationStore;
   }
 
+
+  /**
+   * Sets the ConversationStore used by this servlet. This function provides a common setup method
+   * for use by the test framework or the servlet's init() function.
+   */
+  void setMessageStore(MessageStore messageStore) {
+    this.messageStore = messageStore;
+  }
+
+
   /**
    * This function fires when a user navigates to the conversations page. It gets all of the
    * conversations from the model and forwards to conversations.jsp for rendering the list.
@@ -61,7 +78,13 @@ public class ActivityServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
     List<Conversation> conversations = conversationStore.getAllConversations();
+    List<User> users = userStore.getAllUsers();
+    List<Message> messages = messageStore.getAllMessages();
+
+    request.setAttribute("users", users);
     request.setAttribute("conversations", conversations);
+    request.setAttribute("messages", messages);
+
     request.getRequestDispatcher("/WEB-INF/view/activityFeed.jsp").forward(request, response);
   }
 

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -82,6 +82,10 @@ public class MessageStore {
     return loaded;
   }
 
+  public List<Message> getAllMessages() {
+    return messages;
+  }
+
   /** Add a new message to the current set of messages known to the application. */
   public void addMessage(Message message) {
     messages.add(message);

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -69,6 +69,9 @@ public class UserStore {
     users.addAll(DefaultDataStore.getInstance().getAllUsers());
   }
 
+  public List<User> getAllUsers() {
+    return users;
+  }
   /**
    * Access the User object with the given name.
    *

--- a/src/main/webapp/WEB-INF/view/activityFeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityFeed.jsp
@@ -61,8 +61,8 @@ This code sets the style of the page to be a premade stylesheet and sets title.
 						<%
 						for(User user : users){
 						%>
-						<li>User 
-						"<%= user.getName() %>" was made at time <%=user.getCreationTime()%> </li>
+						<li>
+						<%= user.getName() %> joined the Chat It Up community on <%=user.getCreationTime()%> </li>
 						<%
 						}
 						%>
@@ -84,8 +84,8 @@ This code sets the style of the page to be a premade stylesheet and sets title.
 						<%
 						for(Message message : messages){
 						%>
-						<li>User 
-						"<%= message.getContent() %>" was made at time <%=message.getCreationTime()%> </li>
+						<li>Someone on Chat It Up talked about  
+						"<%= message.getContent() %>" at time <%=message.getCreationTime()%> </li>
 						<%
 						}
 						%>


### PR DESCRIPTION
This update allows the activity feed to access data for and display all messages and all registered users.  I like this change because it makes the activity feed more distinct from the purpose of the conversations page, which wasn't the case before. No bugs discovered yet.